### PR TITLE
Re-renable giphy-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2113,7 +2113,7 @@ packages:
         - language-dockerfile
 
     "Pascal Hartig <phartig@rdrei.net> @passy":
-        # - giphy-api # https://github.com/passy/giphy-api/issues/10
+        - giphy-api
         - optparse-text
 
     "rightfold <rightfold@gmail.com> @rightfold":


### PR DESCRIPTION
giphy-api-0.5.0.0 supports servant 0.9 and builds with current nightly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/passy/stackage/2)

<!-- Reviewable:end -->
